### PR TITLE
Removed usage of ioutil

### DIFF
--- a/buildinfo.go
+++ b/buildinfo.go
@@ -16,7 +16,7 @@ package buildinfo // import "github.com/qqiao/buildinfo"
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 // BuildInfo is the data element representing information for a build.
@@ -28,7 +28,7 @@ type BuildInfo struct {
 // Load loads the build information from the given path.
 func Load(path string) (*BuildInfo, error) {
 	var buildInfo BuildInfo
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/qqiao/buildinfo
 
-go 1.12
+go 1.16


### PR DESCRIPTION
Since ioutil has been deprecated, we will remove any of its usage.

As a result, buildinfo now requires go1.16+