### PR TITLE
Use concurrent instead of parallel.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,1 @@
+FROM qqiao/gitpod-env:latest

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: go get && go build ./... && go test ./...
+    command: go run
+
+

--- a/buildinfo.go
+++ b/buildinfo.go
@@ -43,7 +43,7 @@ func Load(path string) (*BuildInfo, error) {
 // LoadAsync loads the build information from the given path.
 //
 // This function internally invokes the Load funtion in a separate goroutine.
-// This allows the slow file I/O and JSON unmarshalling to be parallelized.
+// This allows the slow file I/O and JSON unmarshalling to be run concurrently.
 func LoadAsync(path string) (<-chan *BuildInfo, <-chan error) {
 	out := make(chan *BuildInfo)
 	errs := make(chan error)


### PR DESCRIPTION
Using concurrent instead of parallel to more accurately describe the
behaviour of goroutines.